### PR TITLE
Java from 1.8 to 1.7. Small styling to get the buttons to look like buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 target/
 **/styles.scss.cache
 gridactionrenderer-demo/src/main/webapp/VAADIN/widgetsets/
+
+rebel.xml

--- a/gridactionrenderer-addon/pom.xml
+++ b/gridactionrenderer-addon/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0-SNAPSHOT</version>
+	<version>1.0-b</version>
 	<name>GridActionRenderer Add-on</name>
 
 	<properties>

--- a/gridactionrenderer-addon/pom.xml
+++ b/gridactionrenderer-addon/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0-b</version>
+	<version>1.1-bp</version>
 	<name>GridActionRenderer Add-on</name>
 
 	<properties>

--- a/gridactionrenderer-addon/pom.xml
+++ b/gridactionrenderer-addon/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer</artifactId>
 	<packaging>jar</packaging>
-	<version>1.2-bp</version>
+	<version>1.3-bp-SNAPSHOT</version>
 	<name>GridActionRenderer Add-on</name>
 
 	<properties>

--- a/gridactionrenderer-addon/pom.xml
+++ b/gridactionrenderer-addon/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1.3-bp</version>
+	<version>1.2-bp</version>
 	<name>GridActionRenderer Add-on</name>
 
 	<properties>

--- a/gridactionrenderer-addon/pom.xml
+++ b/gridactionrenderer-addon/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1.2-bp</version>
+	<version>1.1.3-bp</version>
 	<name>GridActionRenderer Add-on</name>
 
 	<properties>

--- a/gridactionrenderer-addon/pom.xml
+++ b/gridactionrenderer-addon/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer</artifactId>
 	<packaging>jar</packaging>
-	<version>1.1-bp</version>
+	<version>1.1.2-bp</version>
 	<name>GridActionRenderer Add-on</name>
 
 	<properties>

--- a/gridactionrenderer-addon/pom.xml
+++ b/gridactionrenderer-addon/pom.xml
@@ -10,8 +10,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
 		<vaadin.version>7.6.8</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 

--- a/gridactionrenderer-addon/src/main/java/org/vaadin/anna/gridactionrenderer/ActionGrid.java
+++ b/gridactionrenderer-addon/src/main/java/org/vaadin/anna/gridactionrenderer/ActionGrid.java
@@ -34,44 +34,42 @@ import com.vaadin.ui.Grid;
  * Grid connector class instead and simply copy over the contents of the
  * ActionGridConnector.
  */
-public abstract class ActionGrid extends Grid implements
-        GridActionClickListener {
+public abstract class ActionGrid extends Grid implements GridActionClickListener {
 
-    private GridActionRenderer actionRenderer;
+	private GridActionRenderer actionRenderer;
 
-    /**
-     * Constructor.
-     *
-     * @param actions
-     *            all the actions that can be displayed by the default action
-     *            renderer
-     */
-    public ActionGrid(List<GridAction> actions) {
-        super();
-        actionRenderer = createGridActionRenderer(actions);
-    }
+	/**
+	 * Constructor.
+	 *
+	 * @param actions
+	 *            all the actions that can be displayed by the default action
+	 *            renderer
+	 */
+	public ActionGrid(List<GridAction> actions) {
+		super();
+		this.actionRenderer = createGridActionRenderer(actions);
+	}
 
-    /**
-     * Returns the default action renderer.
-     *
-     * @return action renderer
-     */
-    public GridActionRenderer getGridActionRenderer() {
-        return actionRenderer;
-    }
+	/**
+	 * Returns the default action renderer.
+	 *
+	 * @return action renderer
+	 */
+	public GridActionRenderer getGridActionRenderer() {
+		return this.actionRenderer;
+	}
 
-    /**
-     * Creates the default action renderer.
-     *
-     * @param actions
-     *            all the actions that can be displayed by the default action
-     *            renderer
-     * @return action renderer
-     */
-    protected GridActionRenderer createGridActionRenderer(
-            List<GridAction> actions) {
-        GridActionRenderer actionRenderer = new GridActionRenderer(actions);
-        actionRenderer.addActionClickListener(this);
-        return actionRenderer;
-    }
+	/**
+	 * Creates the default action renderer.
+	 *
+	 * @param actions
+	 *            all the actions that can be displayed by the default action
+	 *            renderer
+	 * @return action renderer
+	 */
+	protected GridActionRenderer createGridActionRenderer(List<GridAction> actions) {
+		GridActionRenderer actionRenderer = new GridActionRenderer(actions);
+		actionRenderer.addActionClickListener(this);
+		return actionRenderer;
+	}
 }

--- a/gridactionrenderer-addon/src/main/java/org/vaadin/anna/gridactionrenderer/DownloadActionGrid.java
+++ b/gridactionrenderer-addon/src/main/java/org/vaadin/anna/gridactionrenderer/DownloadActionGrid.java
@@ -34,187 +34,186 @@ import org.vaadin.gridfiledownloader.GridFileDownloader.GridStreamResource;
  */
 public abstract class DownloadActionGrid extends ActionGrid {
 
-    private int downloadTimeout = 3000;
-    private Object downloadItemId = null;
-    private Map<Object, DownloadInfo> downloadActionMap = new HashMap<Object, DownloadInfo>();
-    private GridFileDownloader fileDownloader = null;
+	private int downloadTimeout = 3000;
+	private Object downloadItemId = null;
+	private Map<Object, DownloadInfo> downloadActionMap = new HashMap<Object, DownloadInfo>();
+	private GridFileDownloader fileDownloader = null;
 
-    /**
-     * Constructor.
-     *
-     * @param actions
-     *            all the actions that can be displayed by the default action
-     *            renderer
-     */
-    public DownloadActionGrid(List<GridAction> actions) {
-        super(actions);
-        fileDownloader = createGridFileDownloader();
-        getGridActionRenderer().setFileDownloader(getGridFileDownloader());
-    }
+	/**
+	 * Constructor.
+	 *
+	 * @param actions
+	 *            all the actions that can be displayed by the default action
+	 *            renderer
+	 */
+	public DownloadActionGrid(List<GridAction> actions) {
+		super(actions);
+		this.fileDownloader = createGridFileDownloader();
+		getGridActionRenderer().setFileDownloader(getGridFileDownloader());
+	}
 
-    /**
-     * Called when a rendered grid action icon gets clicked.
-     * <p>
-     * NOTE: when overriding this method, you must call super.click(event) for
-     * download actions to work.
-     */
-    @Override
-    public void click(GridActionClickEvent event) {
-        if (event.getAction() instanceof GridDownloadAction) {
-            downloadActionMap.put(event.getItemId(), new DownloadInfo(
-                    (GridDownloadAction) event.getAction(), new Date()));
-        }
-    }
+	/**
+	 * Called when a rendered grid action icon gets clicked.
+	 * <p>
+	 * NOTE: when overriding this method, you must call super.click(event) for
+	 * download actions to work.
+	 */
+	@Override
+	public void click(GridActionClickEvent event) {
+		if (event.getAction() instanceof GridDownloadAction) {
+			this.downloadActionMap.put(	event.getItemId(),
+										new DownloadInfo((GridDownloadAction) event.getAction(), new Date()));
+		}
+	}
 
-    /**
-     * Returns the default file downloader.
-     *
-     * @return file downloader
-     */
-    public GridFileDownloader getGridFileDownloader() {
-        return fileDownloader;
-    }
+	/**
+	 * Returns the default file downloader.
+	 *
+	 * @return file downloader
+	 */
+	public GridFileDownloader getGridFileDownloader() {
+		return this.fileDownloader;
+	}
 
-    /**
-     * Creates the default file downloader.
-     *
-     * @return file downloader
-     */
-    private GridFileDownloader createGridFileDownloader() {
-        return new GridFileDownloader(this, "report", createStreamResource()) {
-            @Override
-            public void recalculateDownloadColumn() {
-                // download column not needed, downloads triggered by external
-                // calls from the action renderer
-                getState().downloadColumnIndex = -1;
-            }
+	/**
+	 * Creates the default file downloader.
+	 *
+	 * @return file downloader
+	 */
+	private GridFileDownloader createGridFileDownloader() {
+		return new GridFileDownloader(this, "report", createStreamResource()) {
+			@Override
+			public void recalculateDownloadColumn() {
+				// download column not needed, downloads triggered by external
+				// calls from the action renderer
+				getState().downloadColumnIndex = -1;
+			}
 
-            @Override
-            protected void setRowId(Object rowId) {
-                // overridden to gain access to id reference
-                downloadItemId = rowId;
-                super.setRowId(rowId);
-            }
+			@Override
+			protected void setRowId(Object rowId) {
+				// overridden to gain access to id reference
+				DownloadActionGrid.this.downloadItemId = rowId;
+				super.setRowId(rowId);
+			}
 
-            @Override
-            protected boolean waitForRPC() {
-                // wait for an RPC calls from both the GridFileDownloader
-                // extension and the GridActionRenderer
-                Date startDate = new Date();
-                // GridFileDownloader default check
-                if (super.waitForRPC()) {
-                    // additional GridActionRenderer check
-                    while (new Date().getTime() - startDate.getTime() < getDownloadTimeout()) {
-                        if (checkDownloadMap(startDate)) {
-                            return true;
-                        }
-                        try {
-                            Thread.sleep(100);
-                        } catch (InterruptedException ignore) {
-                        }
-                    }
-                }
-                return checkDownloadMap(startDate);
-            }
+			@Override
+			protected boolean waitForRPC() {
+				// wait for an RPC calls from both the GridFileDownloader
+				// extension and the GridActionRenderer
+				Date startDate = new Date();
+				// GridFileDownloader default check
+				if (super.waitForRPC()) {
+					// additional GridActionRenderer check
+					while (new Date().getTime() - startDate.getTime() < getDownloadTimeout()) {
+						if (checkDownloadMap(startDate)) {
+							return true;
+						}
+						try {
+							Thread.sleep(100);
+						} catch (InterruptedException ignore) {
+						}
+					}
+				}
+				return checkDownloadMap(startDate);
+			}
 
-            private boolean checkDownloadMap(Date startDate) {
-                boolean result = false;
-                DownloadInfo downloadInfo = downloadActionMap
-                        .get(downloadItemId);
-                if (downloadInfo != null
-                        && (downloadInfo.date.getTime() - startDate.getTime() < getDownloadTimeout())) {
-                    // no timeout, download can proceed
-                    result = true;
-                }
+			private boolean checkDownloadMap(Date startDate) {
+				boolean result = false;
+				DownloadInfo downloadInfo = DownloadActionGrid.this.downloadActionMap.get(DownloadActionGrid.this.downloadItemId);
+				if (downloadInfo != null
+						&& (downloadInfo.date.getTime() - startDate.getTime() < getDownloadTimeout())) {
+					// no timeout, download can proceed
+					result = true;
+				}
 
-                // go through all the unresolved actions from the downloadAction
-                // map and remove those that have reached their timeout, unless
-                // the key matches the current downloadItemId (will get removed
-                // automatically once processing has finished).
-                for (Entry<Object, DownloadInfo> entry : new HashSet<Entry<Object, DownloadInfo>>(
-                        downloadActionMap.entrySet())) {
-                    if (!entry.getKey().equals(downloadItemId)
-                            && entry.getValue().date.getTime()
-                                    - startDate.getTime() >= getDownloadTimeout()) {
-                        downloadActionMap.remove(entry.getKey());
-                    }
-                }
+				// go through all the unresolved actions from the downloadAction
+				// map and remove those that have reached their timeout, unless
+				// the key matches the current downloadItemId (will get removed
+				// automatically once processing has finished).
+				for (Entry<Object, DownloadInfo> entry : new HashSet<Entry<Object, DownloadInfo>>(
+						DownloadActionGrid.this.downloadActionMap.entrySet())) {
+					if (!entry	.getKey()
+								.equals(DownloadActionGrid.this.downloadItemId)
+							&& entry.getValue().date.getTime() - startDate.getTime() >= getDownloadTimeout()) {
+						DownloadActionGrid.this.downloadActionMap.remove(entry.getKey());
+					}
+				}
 
-                return result;
-            };
+				return result;
+			};
 
-            @Override
-            protected void markProcessed() {
-                downloadActionMap.remove(downloadItemId);
-                super.markProcessed();
-            }
-        };
-    }
+			@Override
+			protected void markProcessed() {
+				DownloadActionGrid.this.downloadActionMap.remove(DownloadActionGrid.this.downloadItemId);
+				super.markProcessed();
+			}
+		};
+	}
 
-    /**
-     * Gets the timeout in milliseconds for triggering the download. If both RPC
-     * calls haven't arrived within this time (in milliseconds), download won't
-     * get triggered.
-     *
-     * @return timeout in milliseconds
-     */
-    public long getDownloadTimeout() {
-        return downloadTimeout;
-    }
+	/**
+	 * Gets the timeout in milliseconds for triggering the download. If both RPC
+	 * calls haven't arrived within this time (in milliseconds), download won't
+	 * get triggered.
+	 *
+	 * @return timeout in milliseconds
+	 */
+	public long getDownloadTimeout() {
+		return this.downloadTimeout;
+	}
 
-    /**
-     * Sets the timeout in milliseconds for triggering the download. If both RPC
-     * calls haven't arrived within this time (in milliseconds), download won't
-     * get triggered.
-     *
-     * @param downloadTimeout
-     *            timeout in milliseconds
-     */
-    public void setDownloadTimeout(int downloadTimeout) {
-        this.downloadTimeout = downloadTimeout;
-    }
+	/**
+	 * Sets the timeout in milliseconds for triggering the download. If both RPC
+	 * calls haven't arrived within this time (in milliseconds), download won't
+	 * get triggered.
+	 *
+	 * @param downloadTimeout
+	 *            timeout in milliseconds
+	 */
+	public void setDownloadTimeout(int downloadTimeout) {
+		this.downloadTimeout = downloadTimeout;
+	}
 
-    /**
-     * Creates a GridStreamResource for the triggered download.
-     *
-     * @return stream resource
-     */
-    public abstract GridStreamResource createStreamResource();
+	/**
+	 * Creates a GridStreamResource for the triggered download.
+	 *
+	 * @return stream resource
+	 */
+	public abstract GridStreamResource createStreamResource();
 
-    /**
-     * Returns the item id of the currently processed download action, or null
-     * if one doesn't exist.
-     *
-     * @return item id of the download action
-     */
-    public Object getDownloadItemId() {
-        return downloadItemId;
-    }
+	/**
+	 * Returns the item id of the currently processed download action, or null
+	 * if one doesn't exist.
+	 *
+	 * @return item id of the download action
+	 */
+	public Object getDownloadItemId() {
+		return this.downloadItemId;
+	}
 
-    /**
-     * Returns the currently processed download action, or null if one doesn't
-     * exist.
-     *
-     * @return download action
-     */
-    public GridDownloadAction getDownloadAction() {
-        DownloadInfo downloadInfo = downloadActionMap.get(downloadItemId);
-        if (downloadInfo != null) {
-            return downloadInfo.action;
-        }
-        return null;
-    }
+	/**
+	 * Returns the currently processed download action, or null if one doesn't
+	 * exist.
+	 *
+	 * @return download action
+	 */
+	public GridDownloadAction getDownloadAction() {
+		DownloadInfo downloadInfo = this.downloadActionMap.get(this.downloadItemId);
+		if (downloadInfo != null) {
+			return downloadInfo.action;
+		}
+		return null;
+	}
 
-    /**
-     * Helper class for downloadActionMap
-     */
-    private static class DownloadInfo {
-        private Date date;
-        private GridDownloadAction action;
+	/**
+	 * Helper class for downloadActionMap
+	 */
+	private static class DownloadInfo {
+		private Date date;
+		private GridDownloadAction action;
 
-        public DownloadInfo(GridDownloadAction action, Date date) {
-            this.action = action;
-            this.date = date;
-        }
-    }
+		public DownloadInfo(GridDownloadAction action, Date date) {
+			this.action = action;
+			this.date = date;
+		}
+	}
 }

--- a/gridactionrenderer-addon/src/main/java/org/vaadin/anna/gridactionrenderer/GridAction.java
+++ b/gridactionrenderer-addon/src/main/java/org/vaadin/anna/gridactionrenderer/GridAction.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.vaadin.event.Action;
-import com.vaadin.server.FontAwesome;
+import com.vaadin.server.Resource;
 import com.vaadin.server.ThemeResource;
 
 /**
@@ -31,122 +31,122 @@ import com.vaadin.server.ThemeResource;
  */
 public class GridAction extends Action {
 
-    private String description;
-    private boolean download = false;
-    private List<String> styleNames = new ArrayList<String>();
+	private String description;
+	private boolean download = false;
+	private List<String> styleNames = new ArrayList<String>();
 
-    /**
-     * Constructor.
-     *
-     * @param iconPath
-     *            path for a ThemeResource icon, required
-     * @param description
-     *            tooltip text, can be null
-     */
-    public GridAction(String iconPath, String description) {
-        super(null);
-        assert iconPath != null;
+	/**
+	 * Constructor.
+	 *
+	 * @param iconPath
+	 *            path for a ThemeResource icon, required
+	 * @param description
+	 *            tooltip text, can be null
+	 */
+	public GridAction(String iconPath, String description) {
+		super(null);
+		assert iconPath != null;
 
-        setIcon(new ThemeResource(iconPath));
-        this.description = description;
-    }
+		setIcon(new ThemeResource(iconPath));
+		this.description = description;
+	}
 
-    /**
-     * Constructor.
-     *
-     * @param icon
-     *            FontAwesome icon, required
-     * @param description
-     *            tooltip text, can be null
-     */
-    public GridAction(FontAwesome icon, String description) {
-        super(null);
-        assert icon != null;
+	/**
+	 * Constructor.
+	 *
+	 * @param icon
+	 *            Resource icon, required
+	 * @param description
+	 *            tooltip text, can be null
+	 */
+	public GridAction(Resource icon, String description) {
+		super(null);
+		assert icon != null;
 
-        setIcon(icon);
-        this.description = description;
-    }
+		setIcon(icon);
+		this.description = description;
+	}
 
-    /**
-     * Constructor. If you want to give the action a tooltip, use
-     * {@link #GridAction(String, String)} instead.
-     *
-     * @param iconPath
-     *            path for a ThemeResource icon, required
-     */
-    public GridAction(String iconPath) {
-        this(iconPath, null);
-    }
+	/**
+	 * Constructor. If you want to give the action a tooltip, use
+	 * {@link #GridAction(String, String)} instead.
+	 *
+	 * @param iconPath
+	 *            path for a ThemeResource icon, required
+	 */
+	public GridAction(String iconPath) {
+		this(iconPath, null);
+	}
 
-    /**
-     * Constructor. If you want to give the action a tooltip, use
-     * {@link #GridAction(FontAwesome, String)} instead.
-     *
-     * @param icon
-     *            FontAwesome icon, required
-     */
-    public GridAction(FontAwesome icon) {
-        this(icon, null);
-    }
+	/**
+	 * Constructor. If you want to give the action a tooltip, use
+	 * {@link #GridAction(Resource, String)} instead.
+	 *
+	 * @param icon
+	 *            Resource icon, required
+	 */
+	public GridAction(Resource icon) {
+		this(icon, null);
+	}
 
-    /**
-     * Returns the description that is displayed as a tooltip for the action
-     * icon.
-     *
-     * @return description
-     */
-    public String getDescription() {
-        return description;
-    }
+	/**
+	 * Returns the description that is displayed as a tooltip for the action
+	 * icon.
+	 *
+	 * @return description
+	 */
+	public String getDescription() {
+		return this.description;
+	}
 
-    /**
-     * Sets the description that is displayed as a tooltip for the action icon.
-     *
-     * @param description
-     *            tooltip text, can be null
-     */
-    public void setDescription(String description) {
-        this.description = description;
-    }
+	/**
+	 * Sets the description that is displayed as a tooltip for the action icon.
+	 *
+	 * @param description
+	 *            tooltip text, can be null
+	 */
+	public void setDescription(String description) {
+		this.description = description;
+	}
 
-    /**
-     * Marks the action as a download action.
-     * <p>
-     * NOTE: this method shouldn't be called except from
-     * {@link GridDownloadAction}.
-     */
-    protected void markDownloadAction() {
-        download = true;
-    }
+	/**
+	 * Marks the action as a download action.
+	 * <p>
+	 * NOTE: this method shouldn't be called except from
+	 * {@link GridDownloadAction}.
+	 */
+	protected void markDownloadAction() {
+		this.download = true;
+	}
 
-    /**
-     * Returns {@code true} if the action is a download action, {@code false}
-     * otherwise.
-     *
-     * @return {@code true} if download action, {@code false} otherwise.
-     */
-    public boolean isDownloadAction() {
-        return download;
-    }
+	/**
+	 * Returns {@code true} if the action is a download action, {@code false}
+	 * otherwise.
+	 *
+	 * @return {@code true} if download action, {@code false} otherwise.
+	 */
+	public boolean isDownloadAction() {
+		return this.download;
+	}
 
-    /**
-     * Adds a custom style name for the action icon.
-     * <p>
-     * NOTE: the styles can't be changed on the fly
-     *
-     * @param styleName
-     *            custom style name
-     */
-    public void addStyleName(String styleName) {
-        styleNames.add(styleName);
-    }
+	/**
+	 * Adds a custom style name for the action icon.
+	 * <p>
+	 * NOTE: the styles can't be changed on the fly
+	 *
+	 * @param styleName
+	 *            custom style name
+	 */
+	public void addStyleName(String styleName) {
+		this.styleNames.add(styleName);
+	}
 
-    /**
-     * Returns the custom style names that have been added for the action icon.
-     *
-     * @return list of custom style names
-     */
-    public List<String> getStyleNames() {
-        return new ArrayList<String>(styleNames);
-    }
+	/**
+	 * Returns the custom style names that have been added for the action icon.
+	 *
+	 * @return list of custom style names
+	 */
+	public List<String> getStyleNames() {
+		return new ArrayList<String>(this.styleNames);
+	}
 }

--- a/gridactionrenderer-addon/src/main/java/org/vaadin/anna/gridactionrenderer/GridAction.java
+++ b/gridactionrenderer-addon/src/main/java/org/vaadin/anna/gridactionrenderer/GridAction.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.vaadin.event.Action;
-import com.vaadin.server.FontAwesome;
+import com.vaadin.server.FontIcon;
 import com.vaadin.server.ThemeResource;
 
 /**
@@ -55,11 +55,11 @@ public class GridAction extends Action {
      * Constructor.
      *
      * @param icon
-     *            FontAwesome icon, required
+     *            FontIcon icon, required
      * @param description
      *            tooltip text, can be null
      */
-    public GridAction(FontAwesome icon, String description) {
+    public GridAction(FontIcon icon, String description) {
         super(null);
         assert icon != null;
 
@@ -80,12 +80,12 @@ public class GridAction extends Action {
 
     /**
      * Constructor. If you want to give the action a tooltip, use
-     * {@link #GridAction(FontAwesome, String)} instead.
+     * {@link #GridAction(FontIcon, String)} instead.
      *
      * @param icon
-     *            FontAwesome icon, required
+     *            FontIcon icon, required
      */
-    public GridAction(FontAwesome icon) {
+    public GridAction(FontIcon icon) {
         this(icon, null);
     }
 

--- a/gridactionrenderer-addon/src/main/java/org/vaadin/anna/gridactionrenderer/client/ActionGridConnector.java
+++ b/gridactionrenderer-addon/src/main/java/org/vaadin/anna/gridactionrenderer/client/ActionGridConnector.java
@@ -19,6 +19,7 @@ import com.google.gwt.dom.client.Element;
 import com.vaadin.client.TooltipInfo;
 import com.vaadin.client.connectors.GridConnector;
 import com.vaadin.shared.ui.Connect;
+import com.vaadin.ui.Grid;
 
 /**
  * There is no built-in tooltip support for custom rendered cells where only a
@@ -27,21 +28,19 @@ import com.vaadin.shared.ui.Connect;
  * overrides the default behaviour to makes that special tooltip handling
  * possible.
  */
-@Connect(org.vaadin.anna.gridactionrenderer.ActionGrid.class)
+@Connect(Grid.class)
 public class ActionGridConnector extends GridConnector {
 
-    @Override
-    public TooltipInfo getTooltipInfo(Element element) {
-        if (element.hasAttribute(GridActionRendererConnector.TOOLTIP)) {
-            return new TooltipInfo(
-                    element.getAttribute(GridActionRendererConnector.TOOLTIP),
-                    null);
-        }
-        return super.getTooltipInfo(element);
-    }
+	@Override
+	public TooltipInfo getTooltipInfo(Element element) {
+		if (element.hasAttribute(GridActionRendererConnector.TOOLTIP)) {
+			return new TooltipInfo(element.getAttribute(GridActionRendererConnector.TOOLTIP), null);
+		}
+		return super.getTooltipInfo(element);
+	}
 
-    @Override
-    public boolean hasTooltip() {
-        return true;
-    }
+	@Override
+	public boolean hasTooltip() {
+		return true;
+	}
 }

--- a/gridactionrenderer-addon/src/main/java/org/vaadin/anna/gridactionrenderer/client/GridActionRenderer.java
+++ b/gridactionrenderer-addon/src/main/java/org/vaadin/anna/gridactionrenderer/client/GridActionRenderer.java
@@ -16,6 +16,7 @@
 package org.vaadin.anna.gridactionrenderer.client;
 
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -86,6 +87,7 @@ public class GridActionRenderer extends WidgetRenderer<String, GridActionPanel> 
 
         private int columnIndex;
         private int rowIndex;
+        private List<Widget> widgets = new LinkedList<>();
 
         public GridActionPanel() {
             super();
@@ -95,7 +97,7 @@ public class GridActionRenderer extends WidgetRenderer<String, GridActionPanel> 
             for (final GridAction gridAction : gridActions) {
 
                 GridActionWidget actionWidget = new GridActionWidget(gridAction);
-                add(actionWidget);
+                widgets.add(actionWidget);
 
                 // special tooltip handling, won't work if the used Grid
                 // implementation doesn't support custom tooltips
@@ -120,6 +122,7 @@ public class GridActionRenderer extends WidgetRenderer<String, GridActionPanel> 
         }
 
         public void setActionVisibility(String data) {
+            clear();
             List<Integer> visibleActionIndexes = new ArrayList<Integer>();
             if (data != null && data.length() > 0) {
                 String[] parts = data.split(",");
@@ -134,12 +137,14 @@ public class GridActionRenderer extends WidgetRenderer<String, GridActionPanel> 
                 }
             }
             int actionCount = 0;
-            for (Widget child : getChildren()) {
+            for (Widget child : widgets) { //getChildren()) {
                 if (child instanceof GridActionWidget) {
                     // update the visibility of all GridActionWidgets
                     boolean visible = visibleActionIndexes.contains(-1)
                             || visibleActionIndexes.contains(actionCount);
-                    child.setVisible(visible);
+                    if(visible) {
+                        add(child);
+                    }
                     ++actionCount;
                 }
             }

--- a/gridactionrenderer-addon/src/main/java/org/vaadin/anna/gridactionrenderer/client/GridActionRenderer.java
+++ b/gridactionrenderer-addon/src/main/java/org/vaadin/anna/gridactionrenderer/client/GridActionRenderer.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.google.gwt.user.client.ui.Button;
+import com.google.gwt.user.client.ui.Composite;
 import org.vaadin.anna.gridactionrenderer.client.GridActionRenderer.GridActionPanel;
 import org.vaadin.anna.gridactionrenderer.client.GridActionRendererState.GridAction;
 
@@ -150,7 +152,7 @@ public class GridActionRenderer extends WidgetRenderer<String, GridActionPanel> 
      * the description is displayed as a tooltip when hovering. If the action
      * has custom styles, those are added to the parent element of this widget.
      */
-    public class GridActionWidget extends Widget {
+    public class GridActionWidget extends Composite {
 
         public GridActionWidget(final GridAction gridAction) {
             boolean hasDescription = gridAction.description != null
@@ -168,22 +170,22 @@ public class GridActionRenderer extends WidgetRenderer<String, GridActionPanel> 
                 }
             }
 
-            DivElement div = Document.get().createDivElement();
+            Button button = new Button();
+            button.setStyleName("grid-action-widget");
 
-            setStylePrimaryName(div, "grid-action-widget");
             for (String styleName : gridAction.styleNames) {
-                setStyleName(div, styleName, true);
+                button.addStyleName(styleName);
             }
 
             if (icon != null) {
-                div.appendChild(icon.getElement());
+                button.getElement().appendChild(icon.getElement());
             }
             if (hasDescription) {
-                div.setAttribute(GridActionRendererConnector.TOOLTIP,
+                button.getElement().setAttribute(GridActionRendererConnector.TOOLTIP,
                         gridAction.description);
             }
 
-            setElement(div);
+            initWidget(button);
         }
 
         /**

--- a/gridactionrenderer-addon/src/main/resources/org/vaadin/anna/gridactionrenderer/public/gridactionrenderer/styles.css
+++ b/gridactionrenderer-addon/src/main/resources/org/vaadin/anna/gridactionrenderer/public/gridactionrenderer/styles.css
@@ -2,6 +2,12 @@
   float: left;
   width: 25px;
   text-align:center;
+  background-image: -webkit-linear-gradient(#fcfcfc, #eee);
+  background-image: linear-gradient(#fcfcfc, #eee);
+  border: 1px solid #d5d5d5;
+  border-radius: 3px;
+  color: #333;
+  margin-right: 2px;
 }
 
 .grid-action-widget span {

--- a/gridactionrenderer-addon/src/main/resources/org/vaadin/anna/gridactionrenderer/public/gridactionrenderer/styles.css
+++ b/gridactionrenderer-addon/src/main/resources/org/vaadin/anna/gridactionrenderer/public/gridactionrenderer/styles.css
@@ -1,3 +1,8 @@
+.grid-action-panel {
+  position: relative;
+  top: -2px;
+}
+
 .grid-action-widget {
   float: left;
   width: 25px;

--- a/gridactionrenderer-demo/pom.xml
+++ b/gridactionrenderer-demo/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer-demo</artifactId>
 	<packaging>war</packaging>
-	<version>1.2-bp</version>
+	<version>1.3-bp-SNAPSHOT</version>
 	<name>GridActionRenderer Add-on Demo</name>
 
 	<properties>

--- a/gridactionrenderer-demo/pom.xml
+++ b/gridactionrenderer-demo/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer-demo</artifactId>
 	<packaging>war</packaging>
-	<version>1.0-b</version>
+	<version>1.1-bp</version>
 	<name>GridActionRenderer Add-on Demo</name>
 
 	<properties>

--- a/gridactionrenderer-demo/pom.xml
+++ b/gridactionrenderer-demo/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer-demo</artifactId>
 	<packaging>war</packaging>
-	<version>1.1.3-bp</version>
+	<version>1.2-bp</version>
 	<name>GridActionRenderer Add-on Demo</name>
 
 	<properties>

--- a/gridactionrenderer-demo/pom.xml
+++ b/gridactionrenderer-demo/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer-demo</artifactId>
 	<packaging>war</packaging>
-	<version>1.0-SNAPSHOT</version>
+	<version>1.0-b</version>
 	<name>GridActionRenderer Add-on Demo</name>
 
 	<properties>

--- a/gridactionrenderer-demo/pom.xml
+++ b/gridactionrenderer-demo/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer-demo</artifactId>
 	<packaging>war</packaging>
-	<version>1.1.2-bp</version>
+	<version>1.1.3-bp</version>
 	<name>GridActionRenderer Add-on Demo</name>
 
 	<properties>

--- a/gridactionrenderer-demo/pom.xml
+++ b/gridactionrenderer-demo/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer-demo</artifactId>
 	<packaging>war</packaging>
-	<version>1.1-bp</version>
+	<version>1.1.2-bp</version>
 	<name>GridActionRenderer Add-on Demo</name>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer-root</artifactId>
 	<packaging>pom</packaging>
-	<version>1.2-bp</version>
+	<version>1.3-bp-SNAPSHOT</version>
 	<name>GridActionRenderer Add-on Root Project</name>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer-root</artifactId>
 	<packaging>pom</packaging>
-	<version>1.1.2-bp</version>
+	<version>1.1.3-bp</version>
 	<name>GridActionRenderer Add-on Root Project</name>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer-root</artifactId>
 	<packaging>pom</packaging>
-	<version>1.0-SNAPSHOT</version>
+	<version>1.0-b</version>
 	<name>GridActionRenderer Add-on Root Project</name>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer-root</artifactId>
 	<packaging>pom</packaging>
-	<version>1.1.3-bp</version>
+	<version>1.2-bp</version>
 	<name>GridActionRenderer Add-on Root Project</name>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer-root</artifactId>
 	<packaging>pom</packaging>
-	<version>1.1-bp</version>
+	<version>1.1.2-bp</version>
 	<name>GridActionRenderer Add-on Root Project</name>
 
 	<modules>

--- a/pom.xml.versionsBackup
+++ b/pom.xml.versionsBackup
@@ -5,7 +5,7 @@
 	<groupId>org.vaadin.anna</groupId>
 	<artifactId>gridactionrenderer-root</artifactId>
 	<packaging>pom</packaging>
-	<version>1.1-bp</version>
+	<version>1.0-b</version>
 	<name>GridActionRenderer Add-on Root Project</name>
 
 	<modules>


### PR DESCRIPTION
Drop java version so more developers can use the add-on as it doesn't use Java8 things.

Style the buttons so that they look like buttons.
